### PR TITLE
remove v prefix in julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia v0.6
+julia 0.6
 HDF5
 Logging


### PR DESCRIPTION
this doesn't really matter, it's just more common to leave the v prefix off

(don't bother re-tagging for this)