### PR TITLE
Fix documentation

### DIFF
--- a/docs/deploy.jl
+++ b/docs/deploy.jl
@@ -1,0 +1,11 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/AsterReader.jl/blob/master/LICENSE
+
+using Documenter
+
+deploydocs(
+    repo = "github.com/JuliaFEM/AsterReader.jl.git",
+    julia = "0.6",
+    target = "build",
+    deps = nothing,
+    make = nothing)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,12 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/AsterReader.jl/blob/master/LICENSE
+
+using Documenter, AsterReader
+
+makedocs(modules=[AsterReader],
+         format = :html,
+         sitename = "AsterReader.jl",
+         pages = [
+                  "Introduction" => "index.md",
+                  "API" => "api.md"
+                 ])

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,17 @@
+# API documentation
+
+## Index
+
+```@index
+```
+
+```@meta
+DocTestSetup = quote
+    using AsterReader
+end
+```
+
+```@autodocs
+Modules = [AsterReader]
+```
+

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,26 +1,21 @@
-# AsterReader.jl documentation
+# AsterReader.jl
 
 ```@contents
+Pages = ["index.md", "api.md"]
 ```
 
-```@meta
-DocTestSetup = quote
-    using AsterReader
-end
+Package can be used to read Code Aster .med and .rmed file formats. To read Code Aster `.med` file (exported using SALOME), one has to write
+```julia
+aster_read_mesh(fn)
+```
+where `fn` is the name of the mesh file. Result is a simple dictionary.
+
+In case of several mesh exists in a single file, one must provide also mesh name, e.g.
+```julia
+aster_read_mesh(fn, mesh_name="my_mesh")
 ```
 
-## Exported functions
+Package can also be used to read results from `.rmed` files. This is still
+highly experimental feature and can be used mainly to compare calculation
+results done using Code Aster to results produced by own FE code.
 
-```@docs
-aster_read_mesh
-```
-
-## Internal functions
-
-```@docs
-```
-
-## Index
-
-```@index
-```


### PR DESCRIPTION
Documentation is not generated automatically. Now fixed. Also use
Documenter.jl internal html generator instead of mkdocs. Generate
API documentation automatically.